### PR TITLE
Fix compatibility issues with torch==1.1.0

### DIFF
--- a/experiments/camera_demo.py
+++ b/experiments/camera_demo.py
@@ -11,7 +11,12 @@ from utils import StyleLoader
 
 def run_demo(args, mirror=False):
 	style_model = Net(ngf=args.ngf)
-	style_model.load_state_dict(torch.load(args.model))
+	model_dict = torch.load(args.model)
+	model_dict_clone = model_dict.copy()
+	for key, value in model_dict_clone.items():
+		if key.endswith(('running_mean', 'running_var')):
+			del model_dict[key]
+	style_model.load_state_dict(model_dict, False)
 	style_model.eval()
 	if args.cuda:
 		style_loader = StyleLoader(args.style_folder, args.style_size)
@@ -57,8 +62,9 @@ def run_demo(args, mirror=False):
 			simg = style_v.cpu().data[0].numpy()
 			img = img.cpu().clamp(0, 255).data[0].numpy()
 		else:
-			simg = style_v.data().numpy()
+			simg = style_v.data.numpy()
 			img = img.clamp(0, 255).data[0].numpy()
+		simg = np.squeeze(simg)
 		img = img.transpose(1, 2, 0).astype('uint8')
 		simg = simg.transpose(1, 2, 0).astype('uint8')
 

--- a/experiments/main.py
+++ b/experiments/main.py
@@ -242,7 +242,12 @@ def evaluate(args):
     style = utils.preprocess_batch(style)
 
     style_model = Net(ngf=args.ngf)
-    style_model.load_state_dict(torch.load(args.model), False)
+    model_dict = torch.load(args.model)
+    model_dict_clone = model_dict.copy()
+    for key, value in model_dict_clone.items():
+        if key.endswith(('running_mean', 'running_var')):
+            del model_dict[key]
+    style_model.load_state_dict(model_dict, False)
 
     if args.cuda:
         style_model.cuda()

--- a/experiments/utils.py
+++ b/experiments/utils.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 from PIL import Image
 from torch.autograd import Variable
-from torch.utils.serialization import load_lua
+from torchfile import load as load_lua
 
 from net import Vgg16
 


### PR DESCRIPTION
- [x] `torch.utils.serialization` [has been removed](https://github.com/pytorch/pytorch/issues/15307#issuecomment-448086741). `torchfile.load` should be used instead.
- [x] Fix the following error according to [suggestions by @alvinwan](https://github.com/zhanghang1989/PyTorch-Multi-Style-Transfer/issues/21#issuecomment-410485687)

```shell
RuntimeError: Error(s) in loading state_dict for Net:
	Unexpected running stats buffer(s) "model1.1.running_mean" and "model1.1.running_var" for InstanceNorm2d with track_running_stats=False. If state_dict is a checkpoint saved before 0.4.0, this may be expected because InstanceNorm2d does not track running stats by default since 0.4.0. Please remove these keys from state_dict. If the running stats are actually needed, instead set track_running_stats=True in InstanceNorm2d to enable them. See the documentation of InstanceNorm2d for details.
```