### PR TITLE
Establish Docker directory

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM pytorch/pytorch:0.4.1-cuda9-cudnn7-devel
+RUN apt update && apt upgrade -y
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install tqdm opencv-python torchfile
+RUN mkdir /style-transfer
+WORKDIR /style-transfer

--- a/Docker/run_docker.sh
+++ b/Docker/run_docker.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm -it --gpus all -v $(pwd)/..:/style-transfer style-transfer


### PR DESCRIPTION
What: Establishes a Docker directory with Dockerfile and run script

Why: The original repo was written for an outdated version of PyTorch,
which makes it hard to run on modern systems without conflicting with
updated versions of the dependencies.

Build the container with 

```bash
cd Docker
docker build -t style-transfer .
```